### PR TITLE
bugfix: only accept ternary operator for vars.

### DIFF
--- a/lib/resty/radixtree.lua
+++ b/lib/resty/radixtree.lua
@@ -30,6 +30,7 @@ local re_find     = ngx.re.find
 local re_match    = ngx.re.match
 local sort_tab    = table.sort
 local ngx_re      = require("ngx.re")
+local ngx_null    = ngx.null
 local empty_table = {}
 
 
@@ -482,7 +483,10 @@ end
 local compare_funcs = {
     ["=="] = function (l_v, r_v)
         if type(r_v) == "number" then
-            return tonumber(l_v) == r_v
+            l_v = tonumber(l_v)
+            if not l_v then
+                return false
+            end
         end
         return l_v == r_v
     end,
@@ -490,14 +494,18 @@ local compare_funcs = {
         return l_v ~= r_v
     end,
     [">"] = function (l_v, r_v)
-        if type(r_v) == "number" then
-            return tonumber(l_v) > r_v
+        l_v = tonumber(l_v)
+        r_v = tonumber(r_v)
+        if not l_v or not r_v then
+            return false
         end
         return l_v > r_v
     end,
     ["<"] = function (l_v, r_v)
-        if type(r_v) == "number" then
-            return tonumber(l_v) < r_v
+        l_v = tonumber(l_v)
+        r_v = tonumber(r_v)
+        if not l_v or not r_v then
+            return false
         end
         return l_v < r_v
     end,
@@ -512,6 +520,10 @@ local compare_funcs = {
 
 
 local function compare_val(l_v, op, r_v, opts)
+    if r_v == ngx_null then
+        r_v = nil
+    end
+
     local com_fun = compare_funcs[op or "=="]
     if not com_fun then
         return false
@@ -589,19 +601,9 @@ local function match_route_opts(route, opts, ...)
         end
 
         for _, route_var in ipairs(route.vars) do
-            local l_v, op, r_v
-            if #route_var == 2 then
-                l_v, r_v = route_var[1], route_var[2]
-                op = "=="
-            else
-                l_v, op, r_v = route_var[1], route_var[2], route_var[3]
-            end
+            local l_v, op, r_v = route_var[1], route_var[2], route_var[3]
             l_v = vars[l_v]
 
-            -- ngx.log(ngx.INFO, l_v, op, r_v)
-            if l_v == nil or r_v == nil then
-                return false
-            end
             if not compare_val(l_v, op, r_v, opts) then
                 return false
             end

--- a/t/vars.t
+++ b/t/vars.t
@@ -17,7 +17,7 @@ __DATA__
                     paths = "/aa",
                     metadata = "metadata /aa",
                     vars = {
-                        {"arg_k", "v"},
+                        {"arg_k", "==", "v"},
                     },
                 }
             })
@@ -71,7 +71,7 @@ nil
                     paths = "/aa",
                     metadata = "metadata /aa",
                     vars = {
-                        {"http_test", "v"},
+                        {"http_test", "==", "v"},
                     }
                 }
             })
@@ -129,9 +129,9 @@ nil
                     paths = "/aa",
                     metadata = "metadata /aa",
                     vars = {
-                        {"arg_k", "v"},
-                        {"host", "localhost"},
-                        {"server_port", "1984"},
+                        {"arg_k", "==", "v"},
+                        {"host", "==", "localhost"},
+                        {"server_port", "==", "1984"},
                     }
                 }
             })
@@ -187,9 +187,9 @@ nil
                     paths = "/aa",
                     metadata = "metadata /aa",
                     vars = {
-                        {"arg_k", "v"},
-                        {"host", "localhost"},
-                        {"server_port", "1984"},
+                        {"arg_k", "==", "v"},
+                        {"host", "==", "localhost"},
+                        {"server_port", "==", "1984"},
                     }
                 }
             })
@@ -351,7 +351,7 @@ nil
                     paths = "/aa",
                     metadata = "metadata /aa",
                     vars = {
-                        {"arg_k", "v"},
+                        {"arg_k", "==", "v"},
                     },
                 },
                 {
@@ -472,3 +472,29 @@ GET /t
 [error]
 --- response_body
 nil
+
+
+
+=== TEST 17: ~= nil
+--- config
+    location /t {
+        content_by_lua_block {
+            local radix = require("resty.radixtree")
+            local rx = radix.new({
+                {
+                    paths = "/aa",
+                    metadata = "metadata /aa",
+                    vars = {
+                        {"arg_k", "~=", nil},
+                    },
+                }
+            })
+            ngx.say(rx:match("/aa", {vars = ngx.var}))
+        }
+    }
+--- request
+GET /t?k=v
+--- no_error_log
+[error]
+--- response_body
+metadata /aa


### PR DESCRIPTION
use case:

```
# it shoud mean the value of argument `k` is not empty
{"arg_k", "~=", nil}
```

but this rule was translation to `{"arg_k", "==", "~="}`, it make user confused.

we should only support accept ternary operator for vars.