### PR TITLE
typo of install dependencies cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ make install
 ### Install Dependencies
 
 ```shell
-make dev
+make deps
 ```
 
 ## Benchmark


### PR DESCRIPTION
According to the Makefile, the command to install dependencies should be `make deps`.