### PR TITLE
test: always include the `.` dir in make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ default: compile
 .PHONY: test
 test: compile
 	TEST_NGINX_LOG_LEVEL=info \
-	prove -I../test-nginx/lib -r -s t/
+	prove -I../test-nginx/lib -I. -r -s t/
 
 
 ### clean:        Remove generated files


### PR DESCRIPTION
```bash
t/multiple.t .... Can't locate t/RX.pm in @INC (you may need to install the t::RX module) (@INC contains: /Users/gerrard/workspace/part-time/personal/lua-resty-radixtree-fork/../test-nginx/lib /usr/local/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0/darwin-thread-multi-2level /usr/local/Cellar/perl/5.32.0/lib/perl5/site_perl/5.32.0 /usr/local/Cellar/perl/5.32.0/lib/perl5/5.32.0/darwin-thread-multi-2level /usr/local/Cellar/perl/5.32.0/lib/perl5/5.32.0 /usr/local/lib/perl5/site_perl/5.32.0) at t/multiple.t line 3.
BEGIN failed--compilation aborted at t/multiple.t line 3.
```
`make test` failed on my OSX system and `prove` complains can't find the `t::RX` module due to the lack of `.` dir in built-in `@INC`, and always include `.` dir can resolve it.