### PR TITLE
optimize: make inserting host match route several times faster

### DIFF
--- a/benchmark/match-hosts.lua
+++ b/benchmark/match-hosts.lua
@@ -5,7 +5,7 @@ local match_times = 1000 * 100
 local path = "/12345"
 local routes = {}
 for i = 1, route_count do
-    routes[i] = {paths = {path}, hosts = {ngx.md5(i)}, metadata = i}
+    routes[i] = {paths = {path}, priority = i, hosts = {ngx.md5(i)}, metadata = i}
 end
 
 local rx = radix.new(routes)

--- a/benchmark/match-wildcard-hosts.lua
+++ b/benchmark/match-wildcard-hosts.lua
@@ -5,7 +5,7 @@ local match_times = 1000 * 50
 local path = "/12345"
 local routes = {}
 for i = 1, route_count do
-    routes[i] = {paths = {path}, hosts = {"*." .. ngx.md5(i)}, metadata = i}
+    routes[i] = {paths = {path}, priority = i, hosts = {"*." .. ngx.md5(i)}, metadata = i}
 end
 
 local rx = radix.new(routes)


### PR DESCRIPTION
Previously, `insert_route` will sort the table with `table.sort`.
The `table.sort` is implemented via quick-sort, which is in O(nlogn)
complexity and perform worse when the table is already mostly sorted.

Since we can ensure the table is sorted before inserting, we can
implement a naive insert sort in O(n) complexity to replace `table.sort`.

Via `time resty -I=./lib -I=./deps/share/lua/5.1 benchmark/match-hosts.lua`
I see an impressive time reduction with this optimization.