### PR TITLE
feat: support '==' between table and str

### DIFF
--- a/lib/resty/radixtree.lua
+++ b/lib/resty/radixtree.lua
@@ -504,7 +504,17 @@ local compare_funcs = {
                 return false
             end
         end
-        return l_v == r_v
+        if type(l_v) == "table" then
+            for _, v in ipairs(l_v) do
+                if v == r_v then
+                    return true
+                end
+            end
+
+            return false
+        else
+            return l_v == r_v
+        end
     end,
     ["~="] = function (l_v, r_v)
         return l_v ~= r_v

--- a/t/vars.t
+++ b/t/vars.t
@@ -533,3 +533,36 @@ metadata /aa
 nil
 nil
 nil
+
+
+
+=== TEST 19: ==: left value is array table
+--- config
+    location /t {
+        content_by_lua_block {
+            local radix = require("resty.radixtree")
+            local rx = radix.new({
+                {
+                    paths = "/aa",
+                    metadata = "metadata /aa",
+                    vars = {
+                        {"x", "==", "a"},
+                    },
+                }
+            })
+
+            ngx.say(rx:match("/aa", {vars = {x = {'a', 'b'}}}))
+            ngx.say(rx:match("/aa", {vars = {x = {'a'}}}))
+            ngx.say(rx:match("/aa", {vars = {x = {'b'}}}))
+            ngx.say(rx:match("/aa", {vars = {x = {}}}))
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+metadata /aa
+metadata /aa
+nil
+nil


### PR DESCRIPTION
The `graphql_root_fields` variable will be a table contains multiple
root fields, so we need this change.