### PR TITLE
chore: update `lua-resty-expr` to version v1.1.0.

### DIFF
--- a/rockspec/lua-resty-radixtree-2.6.1-1.rockspec
+++ b/rockspec/lua-resty-radixtree-2.6.1-1.rockspec
@@ -1,0 +1,37 @@
+package = "lua-resty-radixtree"
+version = "2.6.1-0"
+source = {
+    url = "git://github.com/iresty/lua-resty-radixtree",
+    branch = "v2.6.1",
+}
+
+description = {
+    summary = "Adaptive Radix Trees implemented in Lua for Nginx + Lua",
+    homepage = "https://github.com/api7/lua-resty-radixtree",
+    license = "Apache License 2.0",
+    maintainer = "Yuansheng Wang <membphis@gmail.com>"
+}
+
+dependencies = {
+    "lua-resty-ipmatcher",
+    "lua-resty-expr = 1.1.0",
+}
+
+build = {
+    type = "make",
+    build_variables = {
+            CFLAGS="$(CFLAGS) -std=c99 -g -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast",
+            LIBFLAG="$(LIBFLAG)",
+            LUA_LIBDIR="$(LUA_LIBDIR)",
+            LUA_BINDIR="$(LUA_BINDIR)",
+            LUA_INCDIR="$(LUA_INCDIR)",
+            LUA="$(LUA)",
+        },
+        install_variables = {
+            INST_PREFIX="$(PREFIX)",
+            INST_BINDIR="$(BINDIR)",
+            INST_LIBDIR="$(LIBDIR)",
+            INST_LUADIR="$(LUADIR)",
+            INST_CONFDIR="$(CONFDIR)",
+        },
+}

--- a/rockspec/lua-resty-radixtree-2.6.1-1.rockspec
+++ b/rockspec/lua-resty-radixtree-2.6.1-1.rockspec
@@ -1,5 +1,5 @@
 package = "lua-resty-radixtree"
-version = "2.6.1-0"
+version = "2.6.1-1"
 source = {
     url = "git://github.com/iresty/lua-resty-radixtree",
     branch = "v2.6.1",


### PR DESCRIPTION
@Firstsawyou @spacewander 

close https://github.com/api7/lua-resty-radixtree/issues/90