### PR TITLE
fix: params match should not failed with special symbol

### DIFF
--- a/lib/resty/radixtree.lua
+++ b/lib/resty/radixtree.lua
@@ -460,7 +460,9 @@ local function fetch_pat(path)
         local first_byte = item:byte(1, 1)
         if first_byte == string.byte(":") then
             table.insert(names, res[i]:sub(2))
-            res[i] = [=[([\w\-_\%]+)]=]
+            -- See https://www.rfc-editor.org/rfc/rfc1738.txt BNF for specific URL schemes
+            -- exclude special [":", "*"]
+            res[i] = [=[([\w\-_,!';@&=\%\.\$\(\)\+]+)]=]
 
         elseif first_byte == string.byte("*") then
             local name = res[i]:sub(2)

--- a/lib/resty/radixtree.lua
+++ b/lib/resty/radixtree.lua
@@ -461,8 +461,7 @@ local function fetch_pat(path)
         if first_byte == string.byte(":") then
             table.insert(names, res[i]:sub(2))
             -- See https://www.rfc-editor.org/rfc/rfc1738.txt BNF for specific URL schemes
-            -- exclude special [":", "*"]
-            res[i] = [=[([\w\-_,!';@&=\%\.\$\(\)\+]+)]=]
+            res[i] = [=[([\w\-_;:@&=!',\%\$\.\+\*\(\)]+)]=]
 
         elseif first_byte == string.byte("*") then
             local name = res[i]:sub(2)

--- a/t/parameter.t
+++ b/t/parameter.t
@@ -327,8 +327,8 @@ matched: {"_path":"/name/:name/id/:id"}
             })
 
             local opts = {matched = {}}
-            -- test [";" | "@" | "&" | "="]
-            local meta = rx:match("/file/123&45@ddd=test;", opts)
+            -- test [";" | ":" | "@" | "&" | "="]
+            local meta = rx:match("/file/123&45@dd:d=test;", opts)
             ngx.say("matched: ", json.encode(opts.matched))
             ngx.say("match meta: ", meta)
 
@@ -337,8 +337,8 @@ matched: {"_path":"/name/:name/id/:id"}
             ngx.say("matched: ", json.encode(opts.matched))
             ngx.say("match meta: ", meta)
 
-            -- test uchar.unreserved.extra ["!" | "'" | "(" | ")" | ","]
-            local meta = rx:match("/file/t!es't,(file)", opts)
+            -- test uchar.unreserved.extra ["!" | "*" | "'" | "(" | ")" | ","]
+            local meta = rx:match("/file/t!e*s't,(file)", opts)
             ngx.say("matched: ", json.encode(opts.matched))
             ngx.say("match meta: ", meta)
         }
@@ -348,9 +348,9 @@ GET /t
 --- no_error_log
 [error]
 --- response_body
-matched: {"_path":"/file/:filename","filename":"123&45@ddd=test;"}
+matched: {"_path":"/file/:filename","filename":"123&45@dd:d=test;"}
 match meta: metadata /file/:filename
 matched: {"_path":"/file/:filename","filename":"test_a-b+c.lua$"}
 match meta: metadata /file/:filename
-matched: {"_path":"/file/:filename","filename":"t!es't,(file)"}
+matched: {"_path":"/file/:filename","filename":"t!e*s't,(file)"}
 match meta: metadata /file/:filename

--- a/t/parameter.t
+++ b/t/parameter.t
@@ -312,3 +312,45 @@ match meta: nil
 matched: []
 match meta: metadata /name
 matched: {"_path":"/name/:name/id/:id"}
+
+=== TEST 10: /file/:filename (parameter with special symbol)
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local radix = require("resty.radixtree")
+            local rx = radix.new({
+                {
+                    paths = {"/file/:filename"},
+                    metadata = "metadata /file/:filename",
+                },
+            })
+
+            local opts = {matched = {}}
+            -- test [";" | "@" | "&" | "="]
+            local meta = rx:match("/file/123&45@ddd=test;", opts)
+            ngx.say("matched: ", json.encode(opts.matched))
+            ngx.say("match meta: ", meta)
+
+            -- test uchar.unreserved.safe ["$" | "-" | "_" | "." | "+"]
+            local meta = rx:match("/file/test_a-b+c.lua$", opts)
+            ngx.say("matched: ", json.encode(opts.matched))
+            ngx.say("match meta: ", meta)
+
+            -- test uchar.unreserved.extra ["!" | "'" | "(" | ")" | ","]
+            local meta = rx:match("/file/t!es't,(file)", opts)
+            ngx.say("matched: ", json.encode(opts.matched))
+            ngx.say("match meta: ", meta)
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+matched: {"_path":"/file/:filename","filename":"123&45@ddd=test;"}
+match meta: metadata /file/:filename
+matched: {"_path":"/file/:filename","filename":"test_a-b+c.lua$"}
+match meta: metadata /file/:filename
+matched: {"_path":"/file/:filename","filename":"t!es't,(file)"}
+match meta: metadata /file/:filename

--- a/t/parameter.t
+++ b/t/parameter.t
@@ -313,6 +313,8 @@ matched: []
 match meta: metadata /name
 matched: {"_path":"/name/:name/id/:id"}
 
+
+
 === TEST 10: /file/:filename (parameter with special symbol)
 --- config
     location /t {


### PR DESCRIPTION
update regex for special symbol in parameter matching,  Fix https://github.com/apache/apisix/issues/4046

[rfc1738](https://www.rfc-editor.org/rfc/rfc1738.txt) describes the URL schemes and a valid http path parameter is described as `hsegment` and I think we need support these symbols.
```
; HTTP

httpurl        = "http://" hostport [ "/" hpath [ "?" search ]]
hpath          = hsegment *[ "/" hsegment ]
hsegment       = *[ uchar | ";" | ":" | "@" | "&" | "=" ]
search         = *[ uchar | ";" | ":" | "@" | "&" | "=" ]

uchar          = unreserved | escape

unreserved     = alpha | digit | safe | extra

alpha          = lowalpha | hialpha
digit          = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" |
                 "8" | "9"
safe           = "$" | "-" | "_" | "." | "+"
extra          = "!" | "*" | "'" | "(" | ")" | ","

escape         = "%" hex hex

lowalpha       = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" |
                 "i" | "j" | "k" | "l" | "m" | "n" | "o" | "p" |
                 "q" | "r" | "s" | "t" | "u" | "v" | "w" | "x" |
                 "y" | "z"
hialpha        = "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" |
                 "J" | "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" |
                 "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
hex            = digit | "A" | "B" | "C" | "D" | "E" | "F" |
                 "a" | "b" | "c" | "d" | "e" | "f"
```
