### PR TITLE
perf: add rax_tree_up() to iterate the routes tree

### DIFF
--- a/benchmark/match-prefix.lua
+++ b/benchmark/match-prefix.lua
@@ -1,6 +1,6 @@
 local radix = require("resty.radixtree")
 local route_count = 1000 * 100
-local match_times = 1000 * 1000
+local match_times = 1000 * 1
 
 local routes = {}
 for i = 1, route_count do
@@ -8,7 +8,7 @@ for i = 1, route_count do
 end
 
 local rx = radix.new(routes)
-ngx.say("case 1: route matched ", res)
+ngx.say("case 1: route matched ")
 ngx.update_time()
 local start_time = ngx.now()
 
@@ -27,7 +27,7 @@ ngx.say("time used  : ", used_time, " sec")
 ngx.say("QPS        : ", math.floor(match_times / used_time))
 
 ngx.say("=================")
-ngx.say("case 2: route not matched ", res)
+ngx.say("case 2: route not matched ")
 ngx.update_time()
 start_time = ngx.now()
 

--- a/benchmark/match-prefix.lua
+++ b/benchmark/match-prefix.lua
@@ -1,6 +1,6 @@
 local radix = require("resty.radixtree")
 local route_count = 1000 * 100
-local match_times = 1000 * 1
+local match_times = 1000 * 1000
 
 local routes = {}
 for i = 1, route_count do

--- a/benchmark/match-prefix.lua
+++ b/benchmark/match-prefix.lua
@@ -8,12 +8,30 @@ for i = 1, route_count do
 end
 
 local rx = radix.new(routes)
-
+ngx.say("case 1: route matched ", res)
 ngx.update_time()
 local start_time = ngx.now()
 
 local res
 local path = "/" .. ngx.md5(500) .. "/a"
+for _ = 1, match_times do
+    res = rx:match(path)
+end
+
+ngx.update_time()
+local used_time = ngx.now() - start_time
+ngx.say("matched res: ", res)
+ngx.say("route count: ", route_count)
+ngx.say("match times: ", match_times)
+ngx.say("time used  : ", used_time, " sec")
+ngx.say("QPS        : ", math.floor(match_times / used_time))
+
+ngx.say("=================")
+ngx.say("case 2: route not matched ", res)
+ngx.update_time()
+start_time = ngx.now()
+
+path = "/" .. ngx.md5(route_count + 1) .. "/a"
 for _ = 1, match_times do
     res = rx:match(path)
 end

--- a/lib/resty/radixtree.lua
+++ b/lib/resty/radixtree.lua
@@ -116,6 +116,7 @@ ffi_cdef[[
     void *radix_tree_search(void *t, void *it, const unsigned char *buf,
         size_t len);
     int radix_tree_prev(void *it, const unsigned char *buf, size_t len);
+    int radix_tree_up(void *it, const unsigned char *buf, size_t len);
     int radix_tree_stop(void *it);
 
     void *radix_tree_new_it(void *t);
@@ -833,7 +834,7 @@ local function match_route(self, path, opts, args)
     end
 
     while true do
-        local idx = radix.radix_tree_prev(it, path, #path)
+        local idx = radix.radix_tree_up(it, path, #path)
         if idx <= 0 then
             break
         end

--- a/src/easy_rax.c
+++ b/src/easy_rax.c
@@ -167,6 +167,30 @@ radix_tree_prev(void *it, const unsigned char *buf, size_t len)
 
 
 int
+radix_tree_up(void *it, const unsigned char *buf, size_t len)
+{
+    raxIterator    *iter = it;
+    int             res;
+
+    while (1) {
+        res = raxUp(iter);
+        if (!res) {
+            return -1;
+        }
+
+        if (iter->key_len > len ||
+            memcmp(buf, iter->key, iter->key_len) != 0) {
+            continue;
+        }
+
+        break;
+    }
+
+    return (int)iter->data;
+}
+
+
+int
 radix_tree_stop(void *it)
 {
     if (!it) {

--- a/src/easy_rax.h
+++ b/src/easy_rax.h
@@ -57,6 +57,7 @@ void *radix_tree_find(void *t, const unsigned char *buf, size_t len);
 void *radix_tree_search(void *t, void *it, const unsigned char *buf, size_t len);
 int radix_tree_prev(void *it, const unsigned char *buf, size_t len);
 int radix_tree_next(void *it, const unsigned char *buf, size_t len);
+int radix_tree_up(void *it, const unsigned char *buf, size_t len);
 int radix_tree_stop(void *it);
 
 void *radix_tree_new_it(void *t);

--- a/src/rax.c
+++ b/src/rax.c
@@ -1501,6 +1501,48 @@ int raxIteratorPrevStep(raxIterator *it, int noup) {
     }
 }
 
+
+int raxIteratorUpStep(raxIterator *it) {
+    if (it->flags & RAX_ITER_EOF) {
+        return 1;
+    } else if (it->flags & RAX_ITER_JUST_SEEKED) {
+        it->flags &= ~RAX_ITER_JUST_SEEKED;
+        return 1;
+    }
+
+    /* Save key len, stack items and the node where we are currently
+     * so that on iterator EOF we can restore the current key and state. */
+    size_t orig_key_len = it->key_len;
+    size_t orig_stack_items = it->stack.items;
+    raxNode *orig_node = it->node;
+
+    while(1) {
+        /* Already on head? Can't go up, iteration finished. */
+        if (it->node == it->rt->head) {
+            it->flags |= RAX_ITER_EOF;
+            it->stack.items = orig_stack_items;
+            it->key_len = orig_key_len;
+            it->node = orig_node;
+            return 1;
+        }
+
+        it->node = raxStackPop(&it->stack);
+
+        /* Adjust the current key to represent the node we are
+         * at. */
+        int todel = it->node->iscompr ? it->node->size : 1;
+        raxIteratorDelChars(it,todel);
+
+        /* Return the key: this could be the key we found scanning a new
+         * subtree, or if we did not find a new subtree to explore here,
+         * before giving up with this node, check if it's a key itself. */
+        if (it->node->iskey) {
+            it->data = raxGetData(it->node);
+            return 1;
+        }
+    }
+}
+
 /* Seek an iterator at the specified element.
  * Return 0 if the seek failed for syntax error or out of memory. Otherwise
  * 1 is returned. When 0 is returned for out of memory, errno is set to
@@ -1708,6 +1750,18 @@ int raxNext(raxIterator *it) {
  * returned. In case 0 is returned because of OOM, errno is set to ENOMEM. */
 int raxPrev(raxIterator *it) {
     if (!raxIteratorPrevStep(it,0)) {
+        errno = ENOMEM;
+        return 0;
+    }
+    if (it->flags & RAX_ITER_EOF) {
+        errno = 0;
+        return 0;
+    }
+    return 1;
+}
+
+int raxUp(raxIterator *it) {
+    if (!raxIteratorUpStep(it)) {
         errno = ENOMEM;
         return 0;
     }

--- a/src/rax.h
+++ b/src/rax.h
@@ -200,6 +200,7 @@ void raxStart(raxIterator *it, rax *rt);
 int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len);
 int raxNext(raxIterator *it);
 int raxPrev(raxIterator *it);
+int raxUp(raxIterator *it);
 int raxCompare(raxIterator *iter, const char *op, unsigned char *key, size_t key_len);
 void raxStop(raxIterator *it);
 int raxEOF(raxIterator *it);


### PR DESCRIPTION
As mentioned in #119 .

radix_tree_prev() has a poor performance when the routes raxTree is very large and the path to match can not be matched within the tree.
Adding a new function rax_tree_up() to iterate the raxTree, which jumps to the parent node everytime instead of  scanning all nodes smaller than the current in the tree.

Here is the benchmark results on my machine:
Using rax_tree_up:
resty -I=./lib -I=./deps/share/lua/5.1 benchmark/match-prefix.lua
case 1: route matched
matched res: 500
route count: 100000
match times: 1000
time used  : 0.0010001659393311 sec
QPS        : 999834

case 2: route not matched
matched res:
route count: 100000
match times: 1000
time used  : 0 sec
QPS        : inf


Using rax_tree_prev:
resty -I=./lib -I=./deps/share/lua/5.1 benchmark/match-prefix.lua
case 1: route matched
matched res: 500
route count: 100000
match times: 1000
time used  : 0 sec
QPS        : inf

case 2: route not matched
matched res:
route count: 100000
match times: 1000
time used  : 3.4909999370575 sec
QPS        : 286