### PR TITLE
feat: Custom parameter/segment regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,21 @@ local rx = radix.new({
 })
 ```
 
+### Parameters in Path with a custom regex
+
+You can specify parameters on a path and use a regex to match the parameter segment of the path (see `hsegment` of [RFC1738](https://www.rfc-editor.org/rfc/rfc1738.txt).
+It is not possible to match multiple path segements in this way.
+
+```lua
+local rx = radix.new({
+    {
+        -- matches with `/user/john` but not `/user/` or `/user`
+        paths = {"/user/:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"}, -- for `/user/5b3c7845-b45c-4dc8-8843-0349465e0e62`, `opts.matched.user` will be `5b3c7845-b45c-4dc8-8843-0349465e0e62`
+        metadata = "metadata /user",
+    }
+})
+```
+
 [Back to TOC](#table-of-contents)
 
 # Installation

--- a/t/parameter.t
+++ b/t/parameter.t
@@ -392,3 +392,39 @@ GET /t
 --- response_body
 match meta: /user/:user
 match meta: /user/:user/age/:age
+
+
+
+=== TEST 14: /user/:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local radix = require("resty.radixtree")
+            local rx = radix.new({
+                {
+                    paths = { "/user/:uuid:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})" },
+                    metadata = "metadata /name",
+                },
+            })
+
+            local opts = {matched = {}}
+            local meta = rx:match("/user/5b3c7845-b45c-4dc8-8843-0349465e0e62", opts)
+            ngx.say("match meta: ", meta)
+            ngx.say("matched: ", json.encode(opts.matched))
+
+            opts.matched = {}
+            meta = rx:match("/user/1", opts)
+            ngx.say("match meta: ", meta)
+            ngx.say("matched: ", json.encode(opts.matched))
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+match meta: metadata /name
+matched: {"_path":"/user/:uuid:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})","uuid":"5b3c7845-b45c-4dc8-8843-0349465e0e62"}
+match meta: nil
+matched: []


### PR DESCRIPTION
Good day,

First of thanks for reviewing.

This PR tries to solve one of the issues we see often see which is that we would like to do some basic validation on a parameter.
A case we had was where we would want to route differently depending on if the parameter was a uuid or a number. Another case we see it so avoid passing bad parameters to upstream services.

The solution is this case is to add the regex to the parameter. This is done by adding a colon after the name of the parameter.

In this PR we also move to the usage of regex capture groups for two reasons. The first one being that it allows us to get rid of the `names` array/table and the second one is because it ensures that capture groups from custom regular expressions should not interfere with the route parameters. However, this change comes with a backwards compatibility break as 

Please let me know what you think of the idea
