### PR TITLE
fix: give more priority to longer routes

### DIFF
--- a/lib/resty/radixtree.lua
+++ b/lib/resty/radixtree.lua
@@ -204,6 +204,9 @@ local mt = { __index = _M, __gc = gc_free }
 
 
 local function sort_route(route_a, route_b)
+    if route_a.priority == route_b.priority then
+        return #route_a.path_org > #route_b.path_org
+    end
     return (route_a.priority or 0) > (route_b.priority or 0)
 end
 


### PR DESCRIPTION
Fixes https://github.com/apache/apisix/issues/9366

### Explanation:

when creating different routes that have a common prefix but are differentiated with a parameter, route matching becomes dependent on the registration order.

### Consider the case:

uri for route_a: `/api/:version/test/api/projects/:project_id/clusters/:cluster_id/nodes/?`
uri for route_b: `/api/:version/test/*subpath`

path to be matched: `/api/v4/test/api/projects/saas/clusters/123/nodes/`

Theoretically, the above path should match `route_a` but due to the bug if `route_b` is registered before `route_a`, `route_b` will be matched