### PR TITLE
fix: error occurs if the opt.vars is not passed

### DIFF
--- a/lib/resty/radixtree.lua
+++ b/lib/resty/radixtree.lua
@@ -749,7 +749,7 @@ local function match_route_opts(route, opts, args)
             local len = #hosts
             for i = 1, len, 2 do
                 if str_find(hosts[i+1], ":", 1, true) then
-                    if opts.vars.http_host then
+                    if opts.vars and opts.vars.http_host then
                         host = opts.vars.http_host
                     end
                 else

--- a/t/add.t
+++ b/t/add.t
@@ -221,3 +221,30 @@ GET /t
 --- response_body
 pass
 true
+
+
+
+=== TEST 7: match failed if http_host is not passed
+--- config
+    location /t {
+        content_by_lua_block {
+            local opts = {host = "127.0.0.1"}
+            local radix = require("resty.radixtree")
+            local rx = radix.new({
+                {
+                    paths = {"/aa*"},
+                    hosts = "127.0.0.1:9080",
+                    handler = function (ctx)
+                        ngx.say("pass")
+                    end
+                }
+            })
+            ngx.say(rx:dispatch("/aa", opts))
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+nil

--- a/t/add.t
+++ b/t/add.t
@@ -233,7 +233,7 @@ true
             local rx = radix.new({
                 {
                     paths = {"/aa*"},
-                    hosts = "127.0.0.1:9080",
+                    hosts = {"127.0.0.1:9080"},
                     handler = function (ctx)
                         ngx.say("pass")
                     end


### PR DESCRIPTION
```
content_by_lua_block {
            local opts = {host = "127.0.0.1"}
            local radix = require("resty.radixtree")
            local rx = radix.new({
                {
                    paths = {"/aa*"},
                    hosts = "127.0.0.1:9080",
                    handler = function (ctx)
                        ngx.say("pass")
                    end
                }
            })
            ngx.say(rx:dispatch("/aa", opts))
        }
```
error log:
```
 "2024/04/08 13:12:50 [error] 9216#9216: *1 lua entry thread aborted: runtime error: ...ty-radixtree/lua-resty-radixtree/lib/resty/radixtree.lua:752: attempt to index field 'vars' (a nil value)" (req 0)
# stack traceback:
# coroutine 0:
# 	...ty-radixtree/lua-resty-radixtree/lib/resty/radixtree.lua: in function 'match_route_opts'
# 	...ty-radixtree/lua-resty-radixtree/lib/resty/radixtree.lua:812: in function '_match_from_routes'
# 	...ty-radixtree/lua-resty-radixtree/lib/resty/radixtree.lua:861: in function 'match_route'
# 	...ty-radixtree/lua-resty-radixtree/lib/resty/radixtree.lua:1000: in function 'dispatch'
```