### PR TITLE
fix: allow special characters to be matched in uri params

### DIFF
--- a/lib/resty/radixtree.lua
+++ b/lib/resty/radixtree.lua
@@ -656,7 +656,7 @@ local function fetch_pat(path)
         if first_byte == string.byte(":") then
             table.insert(names, res[i]:sub(2))
             -- See https://www.rfc-editor.org/rfc/rfc1738.txt BNF for specific URL schemes
-            res[i] = [=[([\w\-_;:@&=!',\%\$\.\+\*\(\)]+)]=]
+            res[i] = [=[([^\/]+)]=]
 
         elseif first_byte == string.byte("*") then
             local name = res[i]:sub(2)

--- a/t/parameter.t
+++ b/t/parameter.t
@@ -473,3 +473,32 @@ GET /t
 match meta: long
 match meta: short
 match meta: medium
+
+
+
+=== TEST 14: special characters in parameter should match
+--- config
+    location /t {
+        content_by_lua_block {
+            local json = require("toolkit.json")
+            local radix = require("resty.radixtree")
+            local rx = radix.new({
+                {
+                    paths = {"/name/:name/id"},
+                    metadata = "metadata /name",
+                },
+            })
+
+            local opts = {matched = {}}
+            local meta = rx:match("/name/json%20space/id", opts)
+            ngx.say("match meta: ", meta)
+            ngx.say("matched: ", json.encode(opts.matched))
+        }
+    }
+--- request
+GET /t
+--- no_error_log
+[error]
+--- response_body
+match meta: metadata /name
+matched: {"_path":"/name/:name/id","name":"json%20space"}


### PR DESCRIPTION
The existing regex would cause route matching to fail when there are special characters in the uri parameters. This has been fixed.