### PR TITLE
feat: release v2.9.2

### DIFF
--- a/rockspec/lua-resty-radixtree-2.9.2-0.rockspec
+++ b/rockspec/lua-resty-radixtree-2.9.2-0.rockspec
@@ -16,7 +16,6 @@ dependencies = {
     "lua-resty-expr = 1.3.0",
 }
 
-
 build = {
     type = "make",
     build_variables = {


### PR DESCRIPTION
turns out that the previous release PR caused a failure in release workflow because the release commit was invalid (starting with `chore: `).  Instead, the release title must start with `feat: `.